### PR TITLE
add tslint to frontend

### DIFF
--- a/front/package.json
+++ b/front/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "",
   "scripts": {
+    "lint": "tslint --project tsconfig.json",
     "build": "webpack && copyfiles static dist"
   },
   "author": "",
@@ -13,6 +14,8 @@
     "copyfiles": "^2.2.0",
     "source-map-loader": "^0.2.4",
     "ts-loader": "^6.2.2",
+    "tslint": "^6.1.1",
+    "tslint-react": "^4.2.0",
     "typescript": "^3.8.3",
     "webpack": "^4.42.1",
     "webpack-cli": "^3.3.11"

--- a/front/src/app.tsx
+++ b/front/src/app.tsx
@@ -9,5 +9,5 @@ class App extends React.Component {
 
 ReactDOM.render(
     <App />,
-    document.getElementById("app")
+    document.getElementById("app"),
 );

--- a/front/tslint.json
+++ b/front/tslint.json
@@ -1,0 +1,15 @@
+{
+    "defaultSeverity": "error",
+    "extends": [
+        "tslint:all",
+        "tslint-react"
+    ],
+    "jsRules": {},
+    "rules": {
+        "completed-docs": false,
+        "member-access": false,
+        "prefer-function-over-method": false,
+        "typedef":false
+    },
+    "rulesDirectory": []
+}


### PR DESCRIPTION
a linter is a tool that highlights violations of some style guidelines. Sometimes they are configured to run on PRs to prevent badly formatted code from merging to master or causing endless style arguments.

The most common linter for typescript is tslint. The configuration file for tslint defines the rules it enforces.

I decided to enforce the strictest possible ruleset by default and then explicitly turn off any of the rules that are annoying or that I disagree with. We can turn off more rules as we go.

VS Code can be configured to highlight tslint violations and can even automatically fix many of them for you so usually it's not too terrible of a process because you can fix the style issues as you go.