### PR TITLE
fix copy files command on build

### DIFF
--- a/front/package.json
+++ b/front/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "scripts": {
     "lint": "tslint --project tsconfig.json",
-    "build": "webpack && copyfiles static dist"
+    "build": "webpack && copyfiles static/* dist --flat -V"
   },
   "author": "",
   "license": "MIT",


### PR DESCRIPTION
npm run build is supposed to copy all files in the static folder to the dist folder, but it wasn't working properly. This change fixes it.