### PR TITLE
create root app that depends on front and back

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "gullbog",
+  "version": "1.0.0",
+  "description": "![CI](https://github.com/nturley/gullbog/workflows/CI/badge.svg) # Gullbog",
+  "scripts": {
+    "build": "npm explore gullbog-front -- npm run build",
+    "start": "npm explore gullbog-back -- npm run start"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/nturley/gullbog.git"
+  },
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/nturley/gullbog/issues"
+  },
+  "homepage": "https://github.com/nturley/gullbog#readme",
+  "dependencies": {
+    "gullbog-front": "file:./front",
+    "gullbog-back": "file:./back"
+  }
+}


### PR DESCRIPTION
By default, Heroku builds and deploys nodejs applications by running

- `npm install .`
- `npm run build`
- `npm run start`

The problem is that we have two different npm projects and neither of them are at the root of our repo. I think it's still valuable to separate the frontend and backend packages, so I create one package named gullbog which depends on both gullbog-front and gullbog-back which means that when you `npm install .`, it installs the dependencies for both the front and back. Then we create script commands for build and run that fallback to running build on the frontend and start on the backend.

I think this is all we need to get heroku to work properly.

closes #4 