### PR TITLE
Start adding support for hot module reloading

### DIFF
--- a/front/package.json
+++ b/front/package.json
@@ -4,21 +4,27 @@
   "description": "",
   "scripts": {
     "lint": "tslint --project tsconfig.json",
-    "build": "webpack && copyfiles static dist"
+    "build": "webpack && copyfiles static dist",
+    "start": "concurrently \"webpack-dev-server --hot\" \"opener http://localhost:5000\" ",
+    "clean": "rimraf dist"
   },
   "author": "",
   "license": "MIT",
   "devDependencies": {
     "@types/react": "^16.9.34",
     "@types/react-dom": "^16.9.6",
+    "concurrently": "^5.1.0",
     "copyfiles": "^2.2.0",
+    "opener": "^1.5.1",
     "source-map-loader": "^0.2.4",
     "ts-loader": "^6.2.2",
     "tslint": "^6.1.1",
     "tslint-react": "^4.2.0",
     "typescript": "^3.8.3",
     "webpack": "^4.42.1",
-    "webpack-cli": "^3.3.11"
+    "webpack-cli": "^3.3.11",
+    "webpack-dev-server": "^3.10.3",
+    "rimraf": "^3.0.2"
   },
   "dependencies": {
     "react": "^16.13.1",

--- a/front/webpack.config.js
+++ b/front/webpack.config.js
@@ -1,30 +1,37 @@
+var path = require('path');
+
 module.exports = {
-    mode: "development",
-    entry: './src/app.tsx',
-    devtool: "source-map",
-    resolve: {
-        extensions: [".ts", ".tsx"]
-    },
-    module: {
-        rules: [
-            {
-                test: /\.ts(x?)$/,
-                exclude: /node_modules/,
-                use: [
-                    {
-                        loader: "ts-loader"
-                    }
-                ]
-            },
-            {
-                enforce: "pre",
-                test: /\.js$/,
-                loader: "source-map-loader"
-            }
+  mode: "development",
+  entry: './src/app.tsx',
+  devtool: "source-map",
+  resolve: {
+    extensions: [".ts", ".tsx", ".js"]
+  },
+  module: {
+    rules: [
+      {
+        test: /\.ts(x?)$/,
+        exclude: /node_modules/,
+        use: [
+          {
+            loader: "ts-loader"
+          }
         ]
-    },
-    externals: {
-        "react": "React",
-        "react-dom": "ReactDOM"
-    }
+      },
+      {
+        enforce: "pre",
+        test: /\.js$/,
+        loader: "source-map-loader"
+      }
+    ]
+  },
+  externals: {
+    "react": "React",
+    "react-dom": "ReactDOM"
+  },
+  devServer: {
+    contentBase: path.join(__dirname, 'dist'),
+    compress: true,
+    port: 5000
+  }
 };


### PR DESCRIPTION
There's a bunch of other stuff that needs to be done to swap out modules without losing state, but our app doesn't have state yet, so just refreshing the page on rebuild is good enough for now. Also added an npm clean script.